### PR TITLE
Fix `extract_apk` to recursively create the `extracted` directory

### DIFF
--- a/keyfinder.py
+++ b/keyfinder.py
@@ -1244,7 +1244,7 @@ def extract_apk(apkpath):
         if not os.path.exists(tmppath):
             os.mkdir(tmppath)
         logger.debug('Extracting %s' % getappname(apkpath))
-        os.mkdir(extract_dir)
+        os.makedirs(extract_dir)
         try:
             subprocess.call(['apktool', 'd', apkpath, '-p', tmppath, '-o', extract_dir, '-f'])
         except FileNotFoundError:


### PR DESCRIPTION
This PR implements a fix to the `extract_apk` function so that it recursively creates the intermediate `extracted` directory.

Using `os.mkdir` will fail and throw the `FileNotFoundError` exception if the `extracted` directory does not exist, whereas using `os.makedirs` will tell Python to create both the `extracted` directory and the `extracted/<app_name>` directory.